### PR TITLE
Remove deploy/setup generation from encrypt.sh, simplify docs

### DIFF
--- a/ENCRYPT.md
+++ b/ENCRYPT.md
@@ -1,6 +1,6 @@
 # Cifratura del progetto con PyArmor
 
-Lo script `encrypt.sh` offusca tutti i sorgenti Python del progetto usando [PyArmor 9](https://pyarmor.readthedocs.io/) e produce nella cartella `dist/` un pacchetto pronto al deploy, con i file non-Python copiati intatti.
+Lo script `encrypt.sh` offusca tutti i sorgenti Python del progetto usando [PyArmor 9](https://pyarmor.readthedocs.io/) e produce nella cartella `dist/` il codice cifrato con i file non-Python copiati intatti.
 
 ---
 
@@ -58,45 +58,23 @@ ip link show | grep "link/ether"
 
 ```
 dist/
-├── program/
-│   ├── src/
-│   │   ├── main.py                  ← cifrato
-│   │   ├── pyarmor_runtime_xxxxxx/  ← runtime PyArmor
-│   │   │   ├── __init__.py
-│   │   │   └── pyarmor_runtime.so
-│   │   ├── config.json
-│   │   ├── gateway.log
-│   │   ├── lib/                     ← cifrato
-│   │   ├── modules/                 ← cifrato
-│   │   ├── app/                     ← cifrato
-│   │   └── static/                  ← HTML copiati intatti
-│   └── db/                          ← dati runtime copiati intatti
 ├── requirements.txt
-├── start.sh                         ← avvio applicazione
-└── setup.sh                         ← installazione servizio systemd
+└── program/
+    ├── db/                          ← dati runtime copiati intatti
+    └── src/
+        ├── main.py                  ← cifrato
+        ├── pyarmor_runtime_xxxxxx/  ← runtime PyArmor
+        │   ├── __init__.py
+        │   └── pyarmor_runtime.so
+        ├── config.json
+        ├── gateway.log
+        ├── lib/                     ← cifrato
+        ├── modules/                 ← cifrato
+        ├── app/                     ← cifrato
+        └── static/                  ← HTML copiati intatti
 ```
 
-> I file `.py` originali non vengono modificati. La cartella `dist/` è rigenerata ad ogni esecuzione.
-
----
-
-## Deploy sulla macchina di destinazione
-
-Copia la cartella `dist/` sul server, poi:
-
-```bash
-# Installa dipendenze e crea il servizio systemd
-sudo ./setup.sh
-
-# Oppure avvia manualmente
-./start.sh
-```
-
-### Requisiti sulla macchina di destinazione
-
-- Python 3.x della stessa versione major/minor usata in fase di cifratura
-- Stessa architettura (es. `linux.x86_64`)
-- Se usato `--mac`: la macchina deve avere quell'indirizzo MAC
+> I file `.py` originali non vengono modificati. La cartella `dist/` è rigenerata ad ogni esecuzione. Il deploy sul server è gestito da `setup.sh`.
 
 ---
 

--- a/encrypt.sh
+++ b/encrypt.sh
@@ -118,77 +118,9 @@ if [ -d "$SCRIPT_DIR/program/db" ]; then
     cp -r "$SCRIPT_DIR/program/db" "$OUTPUT_DIR/program/db"
 fi
 
-# Copia requirements.txt e script di avvio
+# Copia requirements.txt
 echo ">>> Copia file di supporto..."
 cp "$SCRIPT_DIR/requirements.txt" "$OUTPUT_DIR/requirements.txt"
-
-# Genera start.sh puntando alla cartella dist
-cat > "$OUTPUT_DIR/start.sh" << 'EOF'
-#!/bin/bash
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-VENV_DIR=""
-for candidate in "$SCRIPT_DIR/.venv" "$SCRIPT_DIR/.env"; do
-    [ -f "$candidate/bin/activate" ] && VENV_DIR="$candidate" && break
-done
-
-[ -n "$VENV_DIR" ] && source "$VENV_DIR/bin/activate"
-
-python3 "$SCRIPT_DIR/program/src/main.py"
-
-[ -n "$VENV_DIR" ] && deactivate
-EOF
-chmod +x "$OUTPUT_DIR/start.sh"
-
-# Genera setup.sh per il deploy del pacchetto cifrato
-cat > "$OUTPUT_DIR/setup.sh" << 'SETUPEOF'
-#!/bin/bash
-set -e
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VENV_DIR="/etc/pesi-gtw/.env"
-SERVICE_FILE="/etc/systemd/system/pesi-gtw.service"
-
-command -v python3 &>/dev/null || { apt update && apt install -y python3; }
-command -v pip3    &>/dev/null || apt install -y python3-pip
-command -v virtualenv &>/dev/null || apt install -y virtualenv
-
-sudo ufw allow 80
-sudo ufw allow 8000
-
-if [ ! -f "$VENV_DIR/bin/activate" ]; then
-    virtualenv "$VENV_DIR"
-fi
-
-source "$VENV_DIR/bin/activate"
-pip install -r "$SCRIPT_DIR/requirements.txt"
-deactivate
-
-if [ -e "$SERVICE_FILE" ]; then
-    echo "Servizio già presente. Aggiornamento..."
-    systemctl stop pesi-gtw.service || true
-fi
-
-cat > "$SERVICE_FILE" << EOF
-[Unit]
-Description=PesiGTW application start
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-WorkingDirectory=$SCRIPT_DIR
-ExecStart=$SCRIPT_DIR/start.sh
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-systemctl daemon-reload
-systemctl enable pesi-gtw.service
-systemctl start pesi-gtw.service
-echo "Servizio avviato."
-SETUPEOF
-chmod +x "$OUTPUT_DIR/setup.sh"
 
 echo ""
 echo "=== Completato ==="


### PR DESCRIPTION
encrypt.sh now only encrypts code and copies assets. All server setup (systemd, firewall) stays in setup.sh. ENCRYPT.md updated accordingly.

https://claude.ai/code/session_01A4nBjRn7Myr8QSQZ7P4vac