### PR TITLE
Improve systemd service setup to support updates

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -52,13 +52,7 @@ source "$VENV_DIR/bin/activate"
 pip install -r "$INSTALL_DIR/requirements.txt"
 deactivate
 
-# Crea il servizio solo se non esiste
-if [ -e "$SERVICE_FILE" ]; then
-    echo "Il file $SERVICE_FILE esiste già. Non è stato creato nulla."
-    exit 1
-fi
-
-# Crea il file systemd
+# Crea o aggiorna il file systemd
 cat > "$SERVICE_FILE" << EOF
 [Unit]
 Description=PesiGTW application start
@@ -74,8 +68,13 @@ Restart=always
 WantedBy=multi-user.target
 EOF
 
-# Attiva il servizio
 systemctl daemon-reload
-systemctl enable pesi-gtw.service
-systemctl start pesi-gtw.service
-echo "Servizio systemd creato e avviato da $INSTALL_DIR."
+
+if systemctl is-enabled --quiet pesi-gtw.service 2>/dev/null; then
+    echo "Servizio systemd aggiornato. Riavvio in corso..."
+    systemctl restart pesi-gtw.service
+else
+    systemctl enable pesi-gtw.service
+    systemctl start pesi-gtw.service
+    echo "Servizio systemd creato e avviato da $INSTALL_DIR."
+fi


### PR DESCRIPTION
## Summary
Modified the setup script to allow updating an existing systemd service instead of failing when the service file already exists. This enables smoother updates and re-deployments without manual service file removal.

## Key Changes
- Removed the check that prevented service file creation if it already existed
- Changed service file creation from one-time setup to idempotent update operation
- Added logic to detect if the service is already enabled and restart it, or enable and start it for new installations
- Improved user feedback with appropriate messages for both new installations and updates

## Implementation Details
- The script now uses `systemctl is-enabled` to check if the service is already active
- For existing services: performs a `systemctl restart` to apply any configuration changes
- For new services: enables and starts the service as before
- Maintains backward compatibility while supporting upgrade scenarios

https://claude.ai/code/session_01LAS4a8JJnFoYTsSqeRp2ko