### PR TITLE
Porta seriale: default vuoto e possibilità di eliminazione

### DIFF
--- a/program/db/setup.json
+++ b/program/db/setup.json
@@ -1,6 +1,6 @@
 {
     "settings_machine": {
-        "name_serial": "/dev/ttyUSB0",
+        "name_serial": "",
         "license_plate_required": false,
         "options_divisions": [
             1,

--- a/program/src/lib/lb_tool.py
+++ b/program/src/lib/lb_tool.py
@@ -41,7 +41,7 @@ class setup_opcua(BaseModel):
 
 class setup_nameserial(BaseModel):
 	token: str
-	name_serial: str
+	name_serial: Union[str, None] = ""
 
 class use_rename(BaseModel):
     use: Union[bool, None]

--- a/program/src/modules/md_webservice.py
+++ b/program/src/modules/md_webservice.py
@@ -696,14 +696,23 @@ def mainprg():
 		try:
 			authorizated = lb_tool.IsAuthorizated(setup_nameserial.token)
 			if authorizated:
-				try:
-					os.system("chmod 777 " + setup_nameserial.name_serial)
-					lb_config.seriale = serial.Serial(setup_nameserial.name_serial, 9600, timeout=0.5)
-				except Exception as e:
-					return {"status_code": 500, "message": str(e)}
-				lb_config.setup["settings_machine"]["name_serial"] = setup_nameserial.name_serial
+				name = setup_nameserial.name_serial or ""
+				if name:
+					try:
+						os.system("chmod 777 " + name)
+						lb_config.seriale = serial.Serial(name, 9600, timeout=0.5)
+					except Exception as e:
+						return {"status_code": 500, "message": str(e)}
+				else:
+					try:
+						if lb_config.seriale and hasattr(lb_config.seriale, "close"):
+							lb_config.seriale.close()
+					except:
+						pass
+					lb_config.seriale = ""
+				lb_config.setup["settings_machine"]["name_serial"] = name
 				if lb_tool.Save(lb_config.path_setup, lb_config.setup):
-					lb_config.nome_seriale = lb_config.setup["settings_machine"]["name_serial"]
+					lb_config.nome_seriale = name
 					return {"status_code": 200, "message": "Porta seriale modificata con successo"}
 			else:
 				message = HTTPException(status_code=404, detail="NOT AUTHORIZATION")


### PR DESCRIPTION
- setup.json: name_serial di default ""
- setup_nameserial: name_serial accetta stringa vuota/None
- SetNomeSeriale: se name_serial è vuoto chiude la connessione seriale esistente e salva "" senza tentare di aprire la porta

https://claude.ai/code/session_012ZHvHMN6erm6qEfpdd9hwV