### PR TITLE
feat: make serial baudrate configurable via setup.json

### DIFF
--- a/program/db/setup.json
+++ b/program/db/setup.json
@@ -1,6 +1,7 @@
 {
     "settings_machine": {
         "name_serial": "",
+        "baudrate": 9600,
         "license_plate_required": false,
         "options_divisions": [
             1,

--- a/program/src/modules/md_pesa_dini.py
+++ b/program/src/modules/md_pesa_dini.py
@@ -212,7 +212,8 @@ def ver():
 	while True:
 		try:
 			if lb_config.nome_seriale:
-				lb_config.seriale = serial.Serial(lb_config.nome_seriale, 9600, timeout=lb_config.timeRead)
+				baudrate = lb_config.setup["settings_machine"].get("baudrate", 9600)
+				lb_config.seriale = serial.Serial(lb_config.nome_seriale, baudrate, timeout=lb_config.timeRead)
 				comando("VER")
 				lb_config.read_seriale = lb_config.seriale.readline().decode().replace("\r\n", "")
 				values = lb_config.read_seriale.split(",")


### PR DESCRIPTION
Added baudrate field to settings_machine in setup.json (default 9600). md_pesa_dini reads it at startup with fallback to 9600 if not set.

https://claude.ai/code/session_01M7eMyNndd4wU4mtc7pQifz