### PR TITLE
feat: baudrate configurable from frontend settings page

### DIFF
--- a/program/src/modules/md_webservice.py
+++ b/program/src/modules/md_webservice.py
@@ -796,6 +796,19 @@ def mainprg():
 				return {"message": "non autenticato"}
 		except:
 			return HTTPException(status_code=400, detail="SYNTAX ERROR")
+
+	@app.get("/setup/baudrate/{baudrate}/{token}")
+	async def SetBaudrate(baudrate: int, token: str):
+		try:
+			if lb_tool.TokenTrue(token):
+				lb_config.setup["settings_machine"]["baudrate"] = baudrate
+				if lb_tool.Save(lb_config.path_setup, lb_config.setup):
+					return {"message": "Modificato con successo"}
+				return {"message": "Errore nel salvataggio"}
+			else:
+				return {"message": "non autenticato"}
+		except:
+			return HTTPException(status_code=400, detail="SYNTAX ERROR")
 	
 	# function to get checksum
 	@app.get("/checksum/{stringa}")

--- a/program/src/static/javascript/settings.js
+++ b/program/src/static/javascript/settings.js
@@ -169,6 +169,7 @@ window.onload = function(){
 			}
 			maxWeight.placeholder = response.message.max_weigth
 			nameSerial.placeholder = response.message.name_serial
+			baudrate.placeholder = response.message.baudrate
 		})
 		body.classList.remove("displayNone")
 	}
@@ -520,6 +521,23 @@ function SaveMaxWeigth(){
 	fetch(urlmaxweigth)
 	.then(response => response.json())
 	.then(response => alert(response.message))
+}
+
+function SaveBaudrate(){
+	let newBaudrate = baudrate.value
+	if(newBaudrate != ""){
+		fetch('http://'+hostname+':8000/setup/baudrate/'+newBaudrate+'/'+token)
+		.then(response => response.json())
+		.then(response => {
+			alert(response.message)
+			if(response.message == "Modificato con successo"){
+				baudrate.placeholder = newBaudrate
+				baudrate.value = ""
+			}
+		})
+	}else{
+		alert("Necessario inserire valore")
+	}
 }
 
 function SetNameSerial(){

--- a/program/src/static/settings.html
+++ b/program/src/static/settings.html
@@ -246,6 +246,13 @@
 				<button class="btn btn-primary btn-outline" id="setNameSerial" type="button" onclick="SetNameSerial()">Salva</button>
 			  </div>
 			</div>
+		  <label for="baudrate">Baudrate</label>
+			<div class="input-group mb-3" style="width: 200px">
+			  <input type="number" class="form-control" placeholder="Baudrate" id="baudrate">
+			  <div class="input-group-append">
+				<button class="btn btn-primary btn-outline" type="button" onclick="SaveBaudrate()">Salva</button>
+			  </div>
+			</div>
 		  <hr>
 		</div> 
 	</div>


### PR DESCRIPTION
Added GET /setup/baudrate/{baudrate}/{token} endpoint, input field in settings.html, and SaveBaudrate() JS function following the same pattern as the serial name and max weight fields.

https://claude.ai/code/session_01M7eMyNndd4wU4mtc7pQifz