### PR TITLE
Nasconde totale netto se net_weight è disabilitato nelle impostazioni

### DIFF
--- a/program/src/static/javascript/records.js
+++ b/program/src/static/javascript/records.js
@@ -170,6 +170,8 @@ window.onload = (event) => {
 					targa.style.display = "none"
 				} else if (element === 'bil') {
 					bil.style.display = "none"
+				} else if (element === 'net_weight') {
+					totalNet.parentElement.style.display = "none"
 				}
 			} else if (response.message.list_settings[element].rename) {
 				document.querySelector(`th:nth-child(${index})`).textContent = response.message.list_settings[element].rename;


### PR DESCRIPTION
Quando la colonna net_weight è disabilitata, oltre a nascondere la colonna "Netto" nella tabella ora nasconde anche il paragrafo "Totale netto" in alto a destra.

https://claude.ai/code/session_01UQ6DbY7WrjADBXSAFDwmBq