### PR TITLE
Fix modal selectors and API response parsing in dashboard

### DIFF
--- a/program/src/static/javascript/dashboard.js
+++ b/program/src/static/javascript/dashboard.js
@@ -213,7 +213,7 @@ function weights2(){
 		.then(result => result.json())
 		.then(result => {
 			console.log(result)
-			result.forEach(pesata => {
+			result.weighings.forEach(pesata => {
 				if(pesata['TARGA'] != ""){
 					var opt = document.createElement('option');
 					opt.value = pesata[1];
@@ -417,15 +417,15 @@ var pesata1 = document.getElementById('pesata1Modal')
 pesata1.addEventListener('show.bs.modal', function (event) {
   var button = event.relatedTarget
   var recipient = button.getAttribute('data-bs-whatever')
-  var modalTitle = exampleModal.querySelector('.modal-title')
-  var modalBodyInput = exampleModal.querySelector('.modal-body input')
+  var modalTitle = pesata1.querySelector('.modal-title')
+  var modalBodyInput = pesata1.querySelector('.modal-body input')
 })
 var pesata2 = document.getElementById('pesata2Modal')
 pesata2.addEventListener('show.bs.modal', function (event) {
   var button = event.relatedTarget
   var recipient = button.getAttribute('data-bs-whatever')
-  var modalTitle = exampleModal.querySelector('.modal-title')
-  var modalBodyInput = exampleModal.querySelector('.modal-body input')
+  var modalTitle = pesata2.querySelector('.modal-title')
+  var modalBodyInput = pesata2.querySelector('.modal-body input')
 })
 
 weight.addEventListener("dblclick", function(event){


### PR DESCRIPTION
## Summary
This PR fixes several bugs in the dashboard JavaScript code related to modal element selection and API response handling.

## Key Changes
- **Fixed API response parsing**: Changed `result.forEach()` to `result.weighings.forEach()` to correctly access the weighings array from the API response object
- **Fixed modal selector references**: Updated `pesata1Modal` event listener to query `pesata1` instead of the undefined `exampleModal` variable
- **Fixed modal selector references**: Updated `pesata2Modal` event listener to query `pesata2` instead of the undefined `exampleModal` variable

## Implementation Details
The changes address two categories of bugs:
1. **API Integration**: The weights2() function was attempting to iterate directly over the API result object instead of accessing the `weighings` property, which would have caused the forEach loop to fail
2. **DOM Manipulation**: The modal event listeners were referencing an undefined `exampleModal` variable instead of the correct modal element variables (`pesata1` and `pesata2`), preventing proper modal initialization

https://claude.ai/code/session_01Tp2i4sEitdRDcMz3s8cYAi