### PR TITLE
Add serial port existence validation before connection

### DIFF
--- a/program/src/modules/md_pesa_dini.py
+++ b/program/src/modules/md_pesa_dini.py
@@ -215,7 +215,7 @@ def ver():
 			if lb_config.nome_seriale:
 				if not os.path.exists(lb_config.nome_seriale):
 					lb_log.error(f"Porta seriale '{lb_config.nome_seriale}' non trovata")
-					time.sleep(5)
+					time.sleep(2)
 					continue
 				baudrate = lb_config.setup["settings_machine"].get("baudrate", 9600)
 				lb_config.seriale = serial.Serial(lb_config.nome_seriale, baudrate, timeout=lb_config.timeRead)

--- a/program/src/modules/md_pesa_dini.py
+++ b/program/src/modules/md_pesa_dini.py
@@ -9,6 +9,7 @@
 # ==============================================================
 import time
 import json
+import os
 import lb_config
 import lb_tool
 import lb_utility
@@ -212,6 +213,10 @@ def ver():
 	while True:
 		try:
 			if lb_config.nome_seriale:
+				if not os.path.exists(lb_config.nome_seriale):
+					lb_log.error(f"Porta seriale '{lb_config.nome_seriale}' non trovata")
+					time.sleep(5)
+					continue
 				baudrate = lb_config.setup["settings_machine"].get("baudrate", 9600)
 				lb_config.seriale = serial.Serial(lb_config.nome_seriale, baudrate, timeout=lb_config.timeRead)
 				comando("VER")

--- a/program/src/modules/md_pesa_dini.py
+++ b/program/src/modules/md_pesa_dini.py
@@ -215,7 +215,7 @@ def ver():
 			if lb_config.nome_seriale:
 				if not os.path.exists(lb_config.nome_seriale):
 					lb_log.error(f"Porta seriale '{lb_config.nome_seriale}' non trovata")
-					time.sleep(2)
+					time.sleep(1)
 					continue
 				baudrate = lb_config.setup["settings_machine"].get("baudrate", 9600)
 				lb_config.seriale = serial.Serial(lb_config.nome_seriale, baudrate, timeout=lb_config.timeRead)


### PR DESCRIPTION
## Summary
Added validation to check if the configured serial port exists before attempting to establish a connection, preventing connection errors and improving error handling.

## Key Changes
- Added `os` module import for file system operations
- Implemented pre-connection validation in the `ver()` function that checks if the serial port path exists using `os.path.exists()`
- Added error logging when the configured serial port is not found
- Implemented a retry mechanism with 1-second delay when the port is unavailable, allowing the system to wait for the port to become available

## Implementation Details
The validation is performed early in the connection attempt loop, before trying to instantiate the `serial.Serial` object. This prevents cryptic serial connection errors and provides clear feedback about missing or unavailable ports. The retry loop allows the system to gracefully handle temporary port unavailability scenarios.

https://claude.ai/code/session_01XqDQMhXWKAYPCGAYwDQdJD