### PR TITLE
Reset read_seriale su eccezione per mostrare pesa scollegata

### DIFF
--- a/program/src/modules/md_pesa_dini.py
+++ b/program/src/modules/md_pesa_dini.py
@@ -36,6 +36,7 @@ def mainprg():
 			lb_config.read_seriale = lb_config.seriale.readline().decode().replace("\r\n", "")
 		except Exception as e:
 			lb_log.error(e)
+			lb_config.read_seriale = ""
 #		print(lb_config.read_seriale)
 		if not lb_config.read_seriale:
 			lb_config.diagnostic["vl"] = ""


### PR DESCRIPTION
Quando il cavo seriale viene scollegato, readline() lancia un'eccezione ma read_seriale manteneva l'ultimo valore valido, impedendo alla dashboard di mostrare "pesa scollegata". Resettando read_seriale a "" nell'except, la condizione in pesata_continua() scatta correttamente.