### PR TITLE
Rileva scollegamento adattatore USB seriale in mainprg

### DIFF
--- a/program/src/modules/md_pesa_dini.py
+++ b/program/src/modules/md_pesa_dini.py
@@ -31,7 +31,14 @@ class RepeatTimer(Timer):
 def mainprg():
 
 	while lb_config.g_enabled:
-		pesata_continua()
+		if lb_config.nome_seriale and not os.path.exists(lb_config.nome_seriale):
+			lb_config.read_seriale = ""
+			time.sleep(1)
+			continue
+		try:
+			pesata_continua()
+		except Exception as e:
+			lb_log.error(e)
 		try:
 			lb_config.read_seriale = lb_config.seriale.readline().decode().replace("\r\n", "")
 		except Exception as e:


### PR DESCRIPTION
Quando l'adattatore USB viene rimosso, il device file sparisce e comando() in pesata_continua() crashava l'intero loop senza aggiornare la dashboard. Fix:
- Controlla os.path.exists() a ogni iterazione: se il device è assente resetta read_seriale e salta l'iterazione (dashboard mostra "pesa scollegata" al giro successivo)
- Wrappa pesata_continua() in try/except per proteggere il loop da eventuali eccezioni di scrittura seriale