### PR TITLE
Chiama pesata_continua() prima del check os.path.exists()

### DIFF
--- a/program/src/modules/md_pesa_dini.py
+++ b/program/src/modules/md_pesa_dini.py
@@ -31,14 +31,14 @@ class RepeatTimer(Timer):
 def mainprg():
 
 	while lb_config.g_enabled:
-		if lb_config.nome_seriale and not os.path.exists(lb_config.nome_seriale):
-			lb_config.read_seriale = ""
-			time.sleep(1)
-			continue
 		try:
 			pesata_continua()
 		except Exception as e:
 			lb_log.error(e)
+		if lb_config.nome_seriale and not os.path.exists(lb_config.nome_seriale):
+			lb_config.read_seriale = ""
+			time.sleep(1)
+			continue
 		try:
 			lb_config.read_seriale = lb_config.seriale.readline().decode().replace("\r\n", "")
 		except Exception as e:


### PR DESCRIPTION
Con l'ordine precedente, il continue saltava pesata_continua() quando il device era assente, quindi lo status non veniva mai aggiornato a "pesa scollegata". Ora pesata_continua() viene sempre chiamata prima: al secondo ciclo dopo la rimozione read_seriale è "" e la dashboard mostra correttamente "pesa scollegata".